### PR TITLE
Try running clang-tidy from workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: clang-tidy --version
+  clang:
+    runs-on: ubuntu-latest
+    steps:
+      - run: clang --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,3 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: ./
+  clang-tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - run: clang-tidy --version


### PR DESCRIPTION
https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md says that clang is installed on the ubuntu18.04 images, IDK if that includes clang-tidy...