### PR TITLE
CI: `npm ci` -> `npm install` for repackaging

### DIFF
--- a/.github/workflows/repackage.yml
+++ b/.github/workflows/repackage.yml
@@ -12,7 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install the new packages.
-        run: npm ci
+        # not `npm ci` because we've changed our dependencies.
+        run: npm install
       - name: Format, lint, test, and package.
         run: npm run all
       - name: See what changed
@@ -26,6 +27,6 @@ jobs:
           add: dist
           author_name: Nick Crews
           author_email: nicholas.b.crews@gmail.com
-          message: 'Re-package dist/* after updating dependencies'
+          message: "Re-package dist/* after updating dependencies"
       - name: "Ensure there are no other unstaged changes lingering"
         run: git diff --quiet --exit-code


### PR DESCRIPTION
I *think* this is what we want?

The whole point of this workflow is to install the
new versions of packages, but `npm ci` just uses
package-lock.json.

See https://github.com/NickCrews/gotoraptor/pull/78/checks?check_run_id=2119142656
where there aren't any changes in dist/ to commit.